### PR TITLE
Compatibility with Splunk Official Extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 	"contributes": {
 		"languages": [
 			{
-				"id": "splunk",
+				"id": "splunk_search",
 				"aliases": [
 					"spl",
 					"SPL",
@@ -37,7 +37,7 @@
 		],
 		"grammars": [
 			{
-				"language": "splunk",
+				"language": "splunk_search",
 				"scopeName": "source.splunk",
 				"path": "./syntaxes/splunk.tmLanguage",
 				"embeddedLanguages": {


### PR DESCRIPTION
Compatibility with the official Splunk extension (id 'splunk' for the language was overridden by the other extension)