### PR TITLE
Option to add support for Markdown Code Blocks in VS Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ Main repo for vscode splunk syntax highlighting
 
 ### Install from Source
 
-Install from source by downloading this repo and unzipping into your vscode extensions directory (ususally `~/.vscode/extensions`)
+Install from source by downloading this repo and unzipping into your vscode extensions directory. The default directories are ususally, 
+
+- Linux/macOS `~/.vscode/extensions`
+- Windows `%USERPROFILE%\.vscode\extensions`
 
 ### Install in Visual Studio Code directly
 

--- a/package.json
+++ b/package.json
@@ -50,15 +50,15 @@
 				}
 			},
 			{
-                "scopeName": "markdown.splunk_search.codeblock",
-                "path": "./syntaxes/splunk_searchcodeblock.json",
-                "injectTo": [
-                    "text.html.markdown"
-                ],
-                "embeddedLanguages": {
-                    "meta.embedded.block.splunk_search": "splunk_search"
-                }
-            }
+				"scopeName": "markdown.splunk_search.codeblock",
+				"path": "./syntaxes/splunk_searchcodeblock.json",
+				"injectTo": [
+					"text.html.markdown"
+                		],
+				"embeddedLanguages": {
+				    "meta.embedded.block.splunk_search": "splunk_search"
+				}
+		}
 		],
 		"snippets": [
 			{

--- a/package.json
+++ b/package.json
@@ -48,7 +48,17 @@
 				"embeddedLanguages": {
 					"meta.embedded.block.sql": "sql"
 				}
-			}
+			},
+			{
+                "scopeName": "markdown.splunk_search.codeblock",
+                "path": "./syntaxes/splunk_searchcodeblock.json",
+                "injectTo": [
+                    "text.html.markdown"
+                ],
+                "embeddedLanguages": {
+                    "meta.embedded.block.splunk_search": "splunk_search"
+                }
+            }
 		],
 		"snippets": [
 			{
@@ -56,5 +66,15 @@
 				"path": "./snippets/splunk_search_snippets.json"
 			}
 		]
+	},
+	"__metadata": {
+		"id": "1938b0e4-e8ca-4c73-b10a-cd715816a50c",
+		"publisherId": "ec8aa3bb-c55d-4e99-ad21-5621f095da29",
+		"publisherDisplayName": "arcsector",
+		"targetPlatform": "undefined",
+		"updated": false,
+		"isPreReleaseVersion": false,
+		"preRelease": false,
+		"installedTimestamp": 1654925390932
 	}
 }

--- a/syntaxes/splunk_searchcodeblock.json
+++ b/syntaxes/splunk_searchcodeblock.json
@@ -1,0 +1,48 @@
+{
+	"fileTypes": [],
+	"injectionSelector": "L:text.html.markdown",
+	"patterns": [
+		{
+			"include": "#spl-code-block"
+		}
+	],
+	"repository": {
+		"spl-code-block": {
+			"begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(spl|jl(doctest)?))((;|\\s)([^`~]*))?$",
+			"name": "markup.fenced_code.block.markdown",
+			"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+			"beginCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				},
+				"4": {
+					"name": "fenced_code.block.language"
+				},
+				"7": {
+					"name": "punctuation.definition.markdown"
+				},
+				"8": {
+					"name": "fenced_code.block.language.attributes"
+				}
+			},
+			"endCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				}
+			},
+			"patterns": [
+				{
+					"begin": "(^|\\G)(\\s*)(.*)",
+					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+					"contentName": "meta.embedded.block.splunk_search",
+					"patterns": [
+						{
+							"include": "source.splunk_search"
+						}
+					]
+				}
+			]
+		}
+	},
+	"scopeName": "markdown.splunk_search.codeblock"
+}


### PR DESCRIPTION
Hi, 

While trying to find a syntax highlighter for Splunk's SPL in Markdown files for VS Code, I found your repo. I updated the packages.json and added a file to syntaxes that would add support for code block highlighting in Markdown files in editor mode for VS Code. I don't believe any existing functionality should be compromised, but I'm new to TypeScript. 

![codeBlockMarkdown](https://user-images.githubusercontent.com/63472938/173175168-b3678a02-ab8b-4eef-bcd0-bcbd7c31aca8.png)