### PR TITLE
Introduce new Splunk block comment in TextMate Language (tmLanguage) grammars

### DIFF
--- a/syntaxes/splunk_search.JSON-tmLanguage
+++ b/syntaxes/splunk_search.JSON-tmLanguage
@@ -74,6 +74,11 @@
       "begin": "query=\\\"",
       "end": "(?<!\\\\)\"",
       "name": "meta.embedded.block.sql"
+    },
+    {
+      "begin": "(?<!\\\\)```",
+      "end": "(?<!\\\\)```",
+      "name": "comment.block.splunk_search"
     }
   ],
   "scopeName": "source.splunk_search"

--- a/syntaxes/splunk_search.tmLanguage
+++ b/syntaxes/splunk_search.tmLanguage
@@ -123,6 +123,14 @@
         <key>name</key>
         <string>meta.embedded.block.sql</string>
       </dict>
+      <dict>
+        <key>begin</key>
+        <string>(?&lt;!\\)```</string>
+        <key>end</key>
+        <string>(?&lt;!\\)```</string>
+        <key>name</key>
+        <string>comment.block.splunk_search</string>
+      </dict>
     </array>
     <key>scopeName</key>
     <string>source.splunk_search</string>


### PR DESCRIPTION
This is a trial-and-error attempt at fixing #4 so it may not be correct. However, in my test, it seems to work.

![Screenshot from 2022-06-23 20-30-01](https://user-images.githubusercontent.com/881987/175374057-6a477d53-9f87-46d5-aabc-bde64999040b.png)
![Screenshot from 2022-06-23 20-13-27](https://user-images.githubusercontent.com/881987/175374062-296edb15-f9c8-4012-b61f-3be2deae3337.png)
